### PR TITLE
Fix php version related unittests

### DIFF
--- a/src/Code/MethodSignatureBuilder.php
+++ b/src/Code/MethodSignatureBuilder.php
@@ -53,7 +53,9 @@ class MethodSignatureBuilder
 
         if ($reflectionMethod->getShortName() == '__construct') {
             $reflectionProperty = $this->findClassProperty($reflectionParameter->getName(), $reflectionClass);
-            if ($reflectionProperty !== null && $reflectionProperty->isPromoted()) {
+            // $reflectionProperty is null when the parameter is not a class property, so checking if isPromoted() is
+            // true is not needed
+            if ($reflectionProperty !== null) {
                 if ($reflectionProperty->isPublic()) {
                     $definition[] = 'public';
                 } elseif ($reflectionProperty->isProtected()) {

--- a/src/Code/MethodSignatureBuilder.php
+++ b/src/Code/MethodSignatureBuilder.php
@@ -64,7 +64,8 @@ class MethodSignatureBuilder
                     $definition[] = 'private';
                 }
 
-                if (PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
+                // isReadOnly() is only available in PHP 8.1 and later, but promoted properties are available in PHP 8.0
+                if (method_exists($reflectionProperty, 'isReadOnly') && $reflectionProperty->isReadOnly()) {
                     $definition[] = 'readonly';
                 }
             }

--- a/src/Code/MethodSignatureBuilder.php
+++ b/src/Code/MethodSignatureBuilder.php
@@ -124,7 +124,7 @@ class MethodSignatureBuilder
         bool $suppressNull = false,
         bool $addIntersectionBrackets = false
     ): string {
-        if (!class_exists(\ReflectionNamedType::class)) {
+        if (!class_exists(\ReflectionNamedType::class, false)) {
             $type = $this->getFQType($reflectionType, $reflectionClass);
 
             return $type;
@@ -159,7 +159,7 @@ class MethodSignatureBuilder
 
     protected function getFQType(ReflectionType $reflectionType, ReflectionClass $reflectionClass): string
     {
-        if (!class_exists(\ReflectionNamedType::class)) {
+        if (!class_exists(\ReflectionNamedType::class, false)) {
             $fqType = (string)$reflectionType;
         } elseif ($reflectionType instanceof \ReflectionNamedType) {
             $fqType = $reflectionType->getName();

--- a/src/Code/MethodSignatureBuilder.php
+++ b/src/Code/MethodSignatureBuilder.php
@@ -62,7 +62,7 @@ class MethodSignatureBuilder
                     $definition[] = 'private';
                 }
 
-                if ($reflectionProperty->isReadOnly()) {
+                if (PHP_VERSION_ID >= 80100 && $reflectionProperty->isReadOnly()) {
                     $definition[] = 'readonly';
                 }
             }

--- a/src/ObjectSeam/CodeBuilder.php
+++ b/src/ObjectSeam/CodeBuilder.php
@@ -98,7 +98,7 @@ class CodeBuilder
         $reflectionType = $reflectionMethod->getReturnType();
 
         $type = 'other';
-        if (!class_exists(\ReflectionNamedType::class)) {
+        if (!class_exists(\ReflectionNamedType::class, false)) {
             $type = (string)$reflectionType;
         } elseif ($reflectionType instanceof \ReflectionNamedType) {
             $type = $reflectionType->getName();


### PR DESCRIPTION
- PHPunit for 7.0 breaks on `class_exists(\ReflectionNamedType::class)`, fixed by specifying that this class should not be autoloaded.
- Fix where in PHP 8.0 a promoted property is checked for `readonly`, while this was introduced in PHP 8.1.